### PR TITLE
Add controller unit tests

### DIFF
--- a/backend/src/modules/auth/auth.controller.spec.ts
+++ b/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,46 @@
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import { User } from '../../entities/user.entity';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let service: jest.Mocked<AuthService>;
+
+  beforeEach(() => {
+    service = {
+      register: jest.fn(),
+      login: jest.fn(),
+    } as any;
+    controller = new AuthController(service);
+  });
+
+  it('should register a user', async () => {
+    const dto = { email: 'a', password: 'b' } as RegisterDto;
+    service.register.mockResolvedValue('user' as any);
+    const result = await controller.register(dto);
+    expect(result).toBe('user');
+    expect(service.register).toHaveBeenCalledWith(dto);
+  });
+
+  it('should login a user', async () => {
+    const dto = { email: 'a', password: 'b' } as LoginDto;
+    service.login.mockResolvedValue('token' as any);
+    const result = await controller.login(dto);
+    expect(result).toBe('token');
+    expect(service.login).toHaveBeenCalledWith(dto);
+  });
+
+  it('should return profile', () => {
+    const user = { id: 'u1', email: 'e', firstName: 'f', lastName: 'l', fullName: 'f l' } as User;
+    const result = controller.getProfile(user);
+    expect(result).toEqual({
+      id: 'u1',
+      email: 'e',
+      firstName: 'f',
+      lastName: 'l',
+      fullName: 'f l',
+    });
+  });
+});

--- a/backend/src/modules/clients/clients.controller.spec.ts
+++ b/backend/src/modules/clients/clients.controller.spec.ts
@@ -1,0 +1,63 @@
+import { ClientsController } from './clients.controller';
+import { ClientsService } from './clients.service';
+import { CreateClientDto } from './dto/create-client.dto';
+import { UpdateClientDto } from './dto/update-client.dto';
+import { User } from '../../entities/user.entity';
+
+describe('ClientsController', () => {
+  let controller: ClientsController;
+  let service: jest.Mocked<ClientsService>;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      findByEmail: jest.fn(),
+    } as any;
+    controller = new ClientsController(service);
+  });
+
+  it('should create a client', async () => {
+    const dto = { name: 'John' } as CreateClientDto;
+    const user = { id: 'u1' } as User;
+    service.create.mockResolvedValue('result' as any);
+    const result = await controller.create(dto, user);
+    expect(result).toBe('result');
+    expect(service.create).toHaveBeenCalledWith(dto, user.id);
+  });
+
+  it('should return all clients', async () => {
+    const user = { id: 'u1' } as User;
+    service.findAll.mockResolvedValue(['c1'] as any);
+    const result = await controller.findAll(user);
+    expect(result).toEqual(['c1']);
+    expect(service.findAll).toHaveBeenCalledWith(user.id);
+  });
+
+  it('should get a client by id', async () => {
+    const user = { id: 'u1' } as User;
+    service.findOne.mockResolvedValue('client' as any);
+    const result = await controller.findOne('123', user);
+    expect(result).toBe('client');
+    expect(service.findOne).toHaveBeenCalledWith('123', user.id);
+  });
+
+  it('should update a client', async () => {
+    const user = { id: 'u1' } as User;
+    const dto = { name: 'Jane' } as UpdateClientDto;
+    service.update.mockResolvedValue('updated' as any);
+    const result = await controller.update('1', dto, user);
+    expect(result).toBe('updated');
+    expect(service.update).toHaveBeenCalledWith('1', dto, user.id);
+  });
+
+  it('should remove a client', async () => {
+    const user = { id: 'u1' } as User;
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove('1', user);
+    expect(service.remove).toHaveBeenCalledWith('1', user.id);
+  });
+});

--- a/backend/src/modules/invoices/invoices.controller.spec.ts
+++ b/backend/src/modules/invoices/invoices.controller.spec.ts
@@ -1,0 +1,130 @@
+import { InvoicesController } from './invoices.controller';
+import { InvoicesService } from './invoices.service';
+import { PdfService } from './pdf.service';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { InvoiceStatus } from '../../entities/invoice.entity';
+import { User } from '../../entities/user.entity';
+import { Response } from 'express';
+
+describe('InvoicesController', () => {
+  let controller: InvoicesController;
+  let service: jest.Mocked<InvoicesService>;
+  let pdfService: jest.Mocked<PdfService>;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      updateStatus: jest.fn(),
+      remove: jest.fn(),
+      findByClient: jest.fn(),
+      findByStatus: jest.fn(),
+      generateInvoiceNumber: jest.fn(),
+      generateInvoicePreview: jest.fn(),
+      generateInvoicePdf: jest.fn(),
+    } as any;
+    pdfService = {} as any;
+    controller = new InvoicesController(service, pdfService);
+  });
+
+  it('should create an invoice', async () => {
+    const dto = { invoiceNumber: 'INV-1' } as CreateInvoiceDto;
+    const user = { id: 'u1' } as User;
+    service.create.mockResolvedValue('invoice' as any);
+    const result = await controller.create(dto, user);
+    expect(result).toBe('invoice');
+    expect(service.create).toHaveBeenCalledWith(dto, user.id);
+  });
+
+  it('should return invoices', async () => {
+    const user = { id: 'u1' } as User;
+    service.findAll.mockResolvedValue(['i1'] as any);
+    const result = await controller.findAll(undefined, undefined, user);
+    expect(result).toEqual(['i1']);
+    expect(service.findAll).toHaveBeenCalledWith(user.id);
+  });
+
+  it('should return invoices by status', async () => {
+    const user = { id: 'u1' } as User;
+    service.findByStatus.mockResolvedValue(['i1'] as any);
+    const result = await controller.findAll(InvoiceStatus.DRAFT, undefined, user);
+    expect(result).toEqual(['i1']);
+    expect(service.findByStatus).toHaveBeenCalledWith(InvoiceStatus.DRAFT, user.id);
+  });
+
+  it('should return invoices by client', async () => {
+    const user = { id: 'u1' } as User;
+    service.findByClient.mockResolvedValue(['i1'] as any);
+    const result = await controller.findAll(undefined, 'c1', user);
+    expect(result).toEqual(['i1']);
+    expect(service.findByClient).toHaveBeenCalledWith('c1', user.id);
+  });
+
+  it('should generate invoice number', async () => {
+    const user = { id: 'u1' } as User;
+    service.generateInvoiceNumber.mockResolvedValue('INV-2');
+    const result = await controller.generateInvoiceNumber(user);
+    expect(result).toEqual({ invoiceNumber: 'INV-2' });
+    expect(service.generateInvoiceNumber).toHaveBeenCalledWith(user.id);
+  });
+
+  it('should get one invoice', async () => {
+    const user = { id: 'u1' } as User;
+    service.findOne.mockResolvedValue('inv' as any);
+    const result = await controller.findOne('1', user);
+    expect(result).toBe('inv');
+    expect(service.findOne).toHaveBeenCalledWith('1', user.id);
+  });
+
+  it('should update an invoice', async () => {
+    const user = { id: 'u1' } as User;
+    const dto = { description: 'u' } as UpdateInvoiceDto;
+    service.update.mockResolvedValue('updated' as any);
+    const result = await controller.update('1', dto, user);
+    expect(result).toBe('updated');
+    expect(service.update).toHaveBeenCalledWith('1', dto, user.id);
+  });
+
+  it('should update invoice status', async () => {
+    const user = { id: 'u1' } as User;
+    service.updateStatus.mockResolvedValue('updated' as any);
+    const result = await controller.updateStatus('1', InvoiceStatus.PAID, user);
+    expect(result).toBe('updated');
+    expect(service.updateStatus).toHaveBeenCalledWith('1', InvoiceStatus.PAID, user.id);
+  });
+
+  it('should remove an invoice', async () => {
+    const user = { id: 'u1' } as User;
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove('1', user);
+    expect(service.remove).toHaveBeenCalledWith('1', user.id);
+  });
+
+  it('should get invoice preview', async () => {
+    const user = { id: 'u1' } as User;
+    service.generateInvoicePreview.mockResolvedValue('html');
+    const result = await controller.getInvoicePreview('1', 'en', user);
+    expect(result).toEqual({ html: 'html' });
+    expect(service.generateInvoicePreview).toHaveBeenCalledWith('1', user.id, 'en');
+  });
+
+  it('should download invoice pdf', async () => {
+    const user = { id: 'u1' } as User;
+    const pdfBuffer = Buffer.from('pdf');
+    service.generateInvoicePdf.mockResolvedValue({ pdfBuffer, invoice: { invoiceNumber: '1' } } as any);
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader: (k: string, v: string) => {
+        headers[k] = v;
+      },
+      end: jest.fn(),
+    } as unknown as Response;
+    await controller.downloadInvoicePdf('1', 'en', res, user);
+    expect(service.generateInvoicePdf).toHaveBeenCalledWith('1', user.id, 'en');
+    expect(headers['Content-Type']).toBe('application/pdf');
+    expect(res.end).toHaveBeenCalledWith(pdfBuffer);
+  });
+});

--- a/backend/src/modules/personal-data/personal-data.controller.spec.ts
+++ b/backend/src/modules/personal-data/personal-data.controller.spec.ts
@@ -1,0 +1,81 @@
+import { PersonalDataController } from './personal-data.controller';
+import { PersonalDataService } from './personal-data.service';
+import { CreatePersonalDataDto } from './dto/create-personal-data.dto';
+import { UpdatePersonalDataDto } from './dto/update-personal-data.dto';
+import { User } from '../../entities/user.entity';
+
+describe('PersonalDataController', () => {
+  let controller: PersonalDataController;
+  let service: jest.Mocked<PersonalDataService>;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      getDefault: jest.fn(),
+      createOrUpdate: jest.fn(),
+    } as any;
+    controller = new PersonalDataController(service);
+  });
+
+  it('should create personal data', async () => {
+    const dto = { businessName: 'biz' } as CreatePersonalDataDto;
+    const user = { id: 'u1' } as User;
+    service.create.mockResolvedValue('pd' as any);
+    const result = await controller.create(dto, user);
+    expect(result).toBe('pd');
+    expect(service.create).toHaveBeenCalledWith(dto, user.id);
+  });
+
+  it('should create or update personal data', async () => {
+    const dto = { businessName: 'biz' } as CreatePersonalDataDto;
+    const user = { id: 'u1' } as User;
+    service.createOrUpdate.mockResolvedValue('pd' as any);
+    const result = await controller.createOrUpdate(dto, user);
+    expect(result).toBe('pd');
+    expect(service.createOrUpdate).toHaveBeenCalledWith(dto, user.id);
+  });
+
+  it('should return all personal data', async () => {
+    const user = { id: 'u1' } as User;
+    service.findAll.mockResolvedValue(['pd'] as any);
+    const result = await controller.findAll(user);
+    expect(result).toEqual(['pd']);
+    expect(service.findAll).toHaveBeenCalledWith(user.id);
+  });
+
+  it('should get default personal data', async () => {
+    const user = { id: 'u1' } as User;
+    service.getDefault.mockResolvedValue('pd' as any);
+    const result = await controller.getDefault(user);
+    expect(result).toBe('pd');
+    expect(service.getDefault).toHaveBeenCalledWith(user.id);
+  });
+
+  it('should find one personal data', async () => {
+    const user = { id: 'u1' } as User;
+    service.findOne.mockResolvedValue('pd' as any);
+    const result = await controller.findOne('1', user);
+    expect(result).toBe('pd');
+    expect(service.findOne).toHaveBeenCalledWith('1', user.id);
+  });
+
+  it('should update personal data', async () => {
+    const user = { id: 'u1' } as User;
+    const dto = { businessName: 'new' } as UpdatePersonalDataDto;
+    service.update.mockResolvedValue('pd' as any);
+    const result = await controller.update('1', dto, user);
+    expect(result).toBe('pd');
+    expect(service.update).toHaveBeenCalledWith('1', dto, user.id);
+  });
+
+  it('should remove personal data', async () => {
+    const user = { id: 'u1' } as User;
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove('1', user);
+    expect(service.remove).toHaveBeenCalledWith('1', user.id);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for auth, clients, invoices and personal-data controllers

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e3484474832b8569b0f5e04157d1