### PR TITLE
Fix stray text in backend entry

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -38,4 +38,4 @@ async function bootstrap() {
   console.log(`Application is running on: http://localhost:${port}`);
   console.log(`Swagger documentation: http://localhost:${port}/api`);
 }
-bootstrap(); 
+bootstrap();


### PR DESCRIPTION
## Summary
- clean up stray shell output at the end of `main.ts`

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6883e2f1efe0832bae9464cc4aba3c53